### PR TITLE
No valid sessions fix.

### DIFF
--- a/AxolotlKit/Classes/Sessions/SessionRecord.h
+++ b/AxolotlKit/Classes/Sessions/SessionRecord.h
@@ -23,4 +23,6 @@
 - (void)promoteState:(SessionState*)promotedState;
 - (void)setState:(SessionState*)sessionState;
 
+- (void)replaceSessionState:(SessionState *)oldSession withSessionState:(SessionState *)newSession;
+
 @end

--- a/AxolotlKit/Classes/Sessions/SessionRecord.m
+++ b/AxolotlKit/Classes/Sessions/SessionRecord.m
@@ -82,7 +82,7 @@
     return NO;
 }
 
-- (SessionState*)sessionState{
+- (SessionState*)sessionState {
     return _sessionState;
 }
 
@@ -110,6 +110,18 @@
 
 - (void)setState:(SessionState *)sessionState{
     self.sessionState = sessionState;
+}
+
+- (void)replaceSessionState:(SessionState *)oldSession withSessionState:(SessionState *)newSession
+{
+    if (self.sessionState == oldSession) {
+        self.sessionState = newSession;
+    }
+    
+    NSUInteger foundIndex = [self.previousStates indexOfObject:oldSession];
+    if (foundIndex != NSNotFound) {
+        [self.previousStates replaceObjectAtIndex:foundIndex withObject:newSession];
+    }
 }
 
 @end

--- a/AxolotlKit/Classes/Sessions/SessionState.h
+++ b/AxolotlKit/Classes/Sessions/SessionState.h
@@ -27,7 +27,7 @@
 
 @end
 
-@interface SessionState : NSObject <NSSecureCoding>
+@interface SessionState : NSObject <NSSecureCoding, NSCopying>
 
 /**
  *  AxolotlSessions are either retreived from the database or initiated on new discussions. They are serialized before being stored to make storing abstractions significantly simpler. Because we propose no abstraction for a contact and TextSecure has multi-device (multiple sessions with same identity key) support, the identityKeys need to be added manually.

--- a/AxolotlKit/Classes/Sessions/SessionState.m
+++ b/AxolotlKit/Classes/Sessions/SessionState.m
@@ -121,6 +121,18 @@ static NSString* const kCoderPendingPrekey    = @"kCoderPendingPrekey";
     [aCoder encodeObject:self.pendingPreKey forKey:kCoderPendingPrekey];
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone {
+    NSMutableData *data = [NSMutableData new];
+    NSKeyedArchiver *archiver = [[NSKeyedArchiver allocWithZone:zone] initForWritingWithMutableData:data];
+    [self encodeWithCoder:archiver];
+    [archiver finishEncoding];
+    
+    NSKeyedUnarchiver *decoder = [[NSKeyedUnarchiver allocWithZone:zone] initForReadingWithData:data];
+    SessionState *sessionState = [[SessionState allocWithZone:zone] initWithCoder:decoder];
+    [decoder finishDecoding];
+    return sessionState;
+}
+
 - (NSData*)senderRatchetKey{
     return [[self senderRatchetKeyPair] publicKey];
 }


### PR DESCRIPTION
It's possible to receive an out-of-order message belonging to different SessionState. In that case we are trying to decrypt message using all SessionStates starting from currentState and then previousStates. We have discovered that in case of failed decryption for current state and successful decryption for one of previous states, both states are saved to the store. In that case only changes in the state that this message belongs to should be preserved.
Fixed this by creating a temporary copy of a state and only saving it when decryption succeeds.

Use case:
1.	Alice sends first message msg1 to Bob	`Alice creates new session A and sends a prekey whisper message to Bob`
2.	Bob sends first message msg2 to Alice	`Bob didn't receive Alice's message yet. Bob creates new session B and sends a prekey whisper message to Alice`
3.	Alice receives Bob's message msg2	`Alice receives a prekey whisper message msg2. Alice creates session B and moves session A to archived sessions`
4.	Bob receives Alice's message msg1	`Bob receives a prekey whisper message msg1. Bob creates session A and moves session B to archived sessions`
5.	Alice sends next message msg3	`Alice sends new message msg3 using current session B`
6.	Bob receives Alice's message msg3	`Bob receives Alice's message msg3 and tries to decrypt using current session A, but fails. Then Bob tries to decrypt message msg3 using archived sessions, in our case only session B, and succeeds. The problem is at this point. Even when decryption with session A failed this session was manipulated and since deception with session B succeeds those changes are going to be saved.`
7.	Bob sends next message to Alice msg4	`Bob sends next message to Alice msg4 using current session A (but manipulated in previous state). Session A for both Alice and Bob are now out of sync. Bob's session A is ahead of Alice's, hence message is encrypted with different message key.`
8.	Alice receives Bob's message msg4	`Alice receives Bob's message msg4. and tries to decrypt using current session B, but fails. Then Alice tries to decrypt message msg4 using archived sessions (A). Unfortunately this time system fails to decrypt message. → Invalid session`